### PR TITLE
fix: corrects the way unarys were stringified

### DIFF
--- a/packages/eslint-codemod-utils/lib/__tests__/index.test.ts
+++ b/packages/eslint-codemod-utils/lib/__tests__/index.test.ts
@@ -19,6 +19,7 @@ import {
   literal,
   staticBlock,
   throwStatement,
+  unaryExpression,
   variableDeclaration,
 } from '..'
 
@@ -181,6 +182,18 @@ describe('jsxMemberExpression', () => {
         property: jsxIdentifier({ name: 'Modal' }),
       }).toString()
     ).eq('AK.Modal')
+  })
+})
+
+describe('unaryExpression', () => {
+  test('basic', () => {
+    expect(
+      unaryExpression({
+        operator: 'typeof',
+        argument: identifier('x'),
+        prefix: true,
+      }).toString()
+    ).eq('typeof x')
   })
 })
 

--- a/packages/eslint-codemod-utils/lib/nodes.ts
+++ b/packages/eslint-codemod-utils/lib/nodes.ts
@@ -252,14 +252,17 @@ export const throwStatement: StringableASTNodeFn<estree.ThrowStatement> = ({
  */
 export const unaryExpression: StringableASTNodeFn<estree.UnaryExpression> = ({
   operator,
+  argument,
+  prefix,
   ...other
 }) => {
   return {
     ...other,
-
     operator,
+    prefix,
+    argument,
     type: 'UnaryExpression',
-    toString: () => operator,
+    toString: () => `${operator} ${node(argument)}`,
   }
 }
 


### PR DESCRIPTION
eg.

```
typeof x
```

would previously render as: 

```
typeof
```