### PR TITLE
Account for additional ts operator

### DIFF
--- a/.changeset/poor-apes-obey.md
+++ b/.changeset/poor-apes-obey.md
@@ -1,0 +1,5 @@
+---
+'eslint-codemod-utils': patch
+---
+
+Updates AST logic to account for additional valid typescript nodes.

--- a/packages/eslint-codemod-utils/lib/__tests__/ts-node.test.ts
+++ b/packages/eslint-codemod-utils/lib/__tests__/ts-node.test.ts
@@ -30,4 +30,22 @@ describe('tsAsExpression', () => {
     const { body } = espree.parse(`const x = 'hello' as World`, ESPREE_OPTIONS)
     expect(node(body[0]).toString()).eq(`const x = 'hello' as World`)
   })
+
+  test('parsed with as type with type parameter', () => {
+    const { body } = espree.parse(
+      `"2" as React.Ref<HTMLDivElement>`,
+      ESPREE_OPTIONS
+    )
+    expect(node(body[0]).toString()).eq(`"2" as React.Ref<HTMLDivElement>`)
+  })
+
+  test('parsed with as type with type parameter', () => {
+    const { body } = espree.parse(
+      `"2" as React.Ref<HTMLDivElement, true>`,
+      ESPREE_OPTIONS
+    )
+    expect(node(body[0]).toString()).eq(
+      `"2" as React.Ref<HTMLDivElement, true>`
+    )
+  })
 })

--- a/packages/eslint-codemod-utils/lib/constants.ts
+++ b/packages/eslint-codemod-utils/lib/constants.ts
@@ -88,8 +88,11 @@ import {
   tsAnyKeyword,
   tsAsExpression,
   tsEmptyBodyFunctionExpression,
+  tsLiteralType,
   tsNullKeyword,
+  tsQualifiedName,
   tsStringKeyword,
+  tsTypeParameterInstantiation,
   tsTypeReference,
 } from './ts-nodes'
 import { identity } from './utils/identity'
@@ -205,6 +208,9 @@ export const typeToHelperLookup = new Proxy(
     TSTypeReference: tsTypeReference,
     TSAnyKeyword: tsAnyKeyword,
     TSNullKeyword: tsNullKeyword,
+    TSQualifiedName: tsQualifiedName,
+    TSTypeParameterInstantiation: tsTypeParameterInstantiation,
+    TSLiteralType: tsLiteralType,
   } as NodeMap,
   {
     // dynamic getter will fail and provide debug information
@@ -214,8 +220,8 @@ export const typeToHelperLookup = new Proxy(
       }
 
       const nodeName = name.toString()
-      throw new Error(`\
-eslint-codemod-utils: type '${nodeName}' missing in typeMap.
+      const error = new Error(`\
+type '${nodeName}' missing in typeMap.
 
 This is probably because the type '${nodeName}' is a Typescript or Flow specific node type. These nodes currently have only partial support.
 
@@ -223,6 +229,8 @@ To resolve this you can:
 * Use a more constrained parser like esprima in your eslint config
 * Lodge a bug at https://github.com/DarkPurple141/eslint-codemod-utils/issues
       `)
+      error.name = 'UnknownNodeError'
+      throw error
     },
   }
 )

--- a/packages/eslint-codemod-utils/lib/ts-nodes.ts
+++ b/packages/eslint-codemod-utils/lib/ts-nodes.ts
@@ -129,3 +129,40 @@ export const tsEmptyBodyFunctionExpression: StringableASTNodeFn<
     toString: () => `function(){}`,
   }
 }
+
+export const tsQualifiedName: StringableASTNodeFn<TSESTree.TSQualifiedName> = ({
+  left,
+  right,
+  ...other
+}) => {
+  return {
+    left,
+    right,
+    ...other,
+    type: AST_NODE_TYPES.TSQualifiedName,
+    toString: () => `${node(left)}.${node(right)}`,
+  }
+}
+
+export const tsTypeParameterInstantiation: StringableASTNodeFn<
+  TSESTree.TSTypeParameterInstantiation
+> = ({ params, ...other }) => {
+  return {
+    params,
+    ...other,
+    type: AST_NODE_TYPES.TSTypeParameterInstantiation,
+    toString: () => `<${params.map(node).join(', ')}>`,
+  }
+}
+
+export const tsLiteralType: StringableASTNodeFn<TSESTree.TSLiteralType> = ({
+  literal,
+  ...other
+}) => {
+  return {
+    literal,
+    ...other,
+    type: AST_NODE_TYPES.TSLiteralType,
+    toString: () => `${node(literal)}`,
+  }
+}


### PR DESCRIPTION
This provides support for nodes like:

```
const thing as React.Ref<HTMLDivElement, true>
```

```
const thing as React.Ref
```